### PR TITLE
Previously, there was a bug in the validator that caused an infinite …

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -4,7 +4,7 @@ use constants::{MANDATORY_PROMPT, OPTIONAL_PROMPT};
 use doogie::constants::NodeType;
 use doogie::Node;
 use errors::{HowserError, HowserResult};
-use std::fmt::{Debug, Formatter, Error};
+use std::fmt::{Debug, Error, Formatter};
 
 /// Element-Level match types for `Node`s.
 #[derive(PartialEq, Clone, Debug)]
@@ -79,7 +79,13 @@ pub struct ContentMatchPair(pub PromptToken, pub Option<String>);
 
 impl Debug for ContentMatchPair {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "<Token: {:?}, String: {:?}, Match: {}>", self.0, self.1, Self::is_match(self))
+        write!(
+            f,
+            "<Token: {:?}, String: {:?}, Match: {}>",
+            self.0,
+            self.1,
+            Self::is_match(self)
+        )
     }
 }
 


### PR DESCRIPTION
…loop when processing repeatable, optional, wildcard tokens. This commit adds some logic to handle that case. Closes issue #8.