### PR TITLE
Improvement update error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ doogie = { git="https://github.com/PolySync/doogie" }
 regex = "0.2"
 env_logger = "0.5.9"
 log = "0.4.1"
+termion = "1"
 
 [dev-dependencies]
 proptest = "0.3.3"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -5,45 +5,37 @@ extern crate doogie;
 extern crate env_logger;
 extern crate howser;
 
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use doogie::parse_document;
 use howser::document::Document;
 use howser::errors::{HowserError, HowserResult, ValidationProblem};
-use howser::helpers::cli::ShellText;
 use howser::reporters::{make_cli_report, CLIOption};
 use howser::validator::Validator;
 use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
+use std::str;
 
 fn main() {
     env_logger::init();
 
-    let matches = make_app().get_matches();
-    let (issues, mut options) = match matches.subcommand() {
+    let app = make_app();
+    let matches = app.get_matches();
+    let (issues, options) = match matches.subcommand() {
         ("check", Some(sub_m)) => {
-            let success_msg = ShellText::OkColor(Box::new(ShellText::Literal(
-                "Valid Rx".to_string(),
-            ))).to_string();
-            let failure_msg = ShellText::ErrorColor(Box::new(ShellText::Literal(
-                "Invalid Rx".to_string(),
-            ))).to_string();
-            (
-                check(sub_m),
-                vec![
-                    CLIOption::SuccessMessage(success_msg),
-                    CLIOption::FailureMessage(failure_msg),
-                ],
-            )
+            let options = vec![CLIOption::VerboseMode(sub_m.is_present("verbose"))];
+            (check(sub_m), options)
         }
-        ("validate", Some(sub_m)) => (validate(sub_m), Vec::new()),
+        ("validate", Some(sub_m)) => {
+            let options = vec![CLIOption::VerboseMode(sub_m.is_present("verbose"))];
+            (validate(sub_m), options)
+        }
         _ => (
-            Err(HowserError::Usage(String::from(matches.usage()))),
+            Err(HowserError::Usage(matches.usage().to_string())),
             Vec::new(),
         ),
     };
 
-    options.push(CLIOption::VerboseMode(matches.is_present("verbose")));
     match issues {
         Ok(issues) => {
             let cli_report = make_cli_report(&issues, options);
@@ -61,15 +53,22 @@ fn make_app<'a, 'b>() -> App<'a, 'b> {
     App::new("Howser")
         .about("Document conformity validator for the Rx spec.")
         .version(crate_version!())
-        .arg(
-            Arg::with_name("verbose")
-                .short("v")
-                .long("verbose")
-                .help("Use verbose (multiline) output for errors and warnings."),
-        )
+        .version_message("Prints version information.")
+        .help_message("Prints help information.")
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .setting(AppSettings::VersionlessSubcommands)
+        .setting(AppSettings::DisableHelpSubcommand)
         .subcommand(
             SubCommand::with_name("check")
-                .about("Checks that a document intended for use as a prescription conforms to the Rx spec.")
+                .about("Verifies that an .rx file conforms to the Rx spec.")
+                .help_message("Prints help information.")
+                .setting(AppSettings::ArgRequiredElseHelp)
+                .arg(
+                    Arg::with_name("verbose")
+                        .short("v")
+                        .long("verbose")
+                        .help("Use verbose (multiline) output for errors and warnings."),
+                )
                 .arg(
                     Arg::with_name("prescription")
                         .required(true)
@@ -80,7 +79,15 @@ fn make_app<'a, 'b>() -> App<'a, 'b> {
         )
         .subcommand(
             SubCommand::with_name("validate")
-                .about("Validate a Markdown document against an Rx Prescription file.")
+                .about("Validate a Markdown document against an .rx Prescription file.")
+                .help_message("Prints help information.")
+                .setting(AppSettings::ArgRequiredElseHelp)
+                .arg(
+                    Arg::with_name("verbose")
+                        .short("v")
+                        .long("verbose")
+                        .help("Use verbose (multiline) output for errors and warnings."),
+                )
                 .arg(
                     Arg::with_name("prescription")
                         .required(true)
@@ -124,6 +131,7 @@ fn check(args: &ArgMatches) -> HowserResult<Option<ValidationProblem>> {
         let filename = String::from(filename);
         let rx_root = parse_document(&get_file_contents(&filename)?);
         let document = Document::new(&rx_root, Some(filename))?;
+
         match document.into_prescription() {
             Err(HowserError::PrescriptionError(warning)) => Ok(Some(Box::new(warning))),
             Err(error) => Err(error),

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -219,7 +219,7 @@ mod tests {
     fn test_check_subcommand_requires_enough_args() {
         let app = super::make_app();
         if let Err(e) = app.get_matches_from_safe(vec!["howser", "check"]) {
-            assert_eq!(e.kind, ErrorKind::MissingRequiredArgument);
+            assert_eq!(e.kind, ErrorKind::MissingArgumentOrSubcommand);
         } else {
             panic!();
         }

--- a/src/document.rs
+++ b/src/document.rs
@@ -10,7 +10,6 @@ use data::ElementType;
 use data::{MatchType, NodeData};
 use doogie::constants::*;
 use doogie::Node;
-use doogie::NodeGetter;
 use errors::{HowserError, HowserResult, SpecWarning};
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/src/document.rs
+++ b/src/document.rs
@@ -10,6 +10,7 @@ use data::ElementType;
 use data::{MatchType, NodeData};
 use doogie::constants::*;
 use doogie::Node;
+use doogie::NodeGetter;
 use errors::{HowserError, HowserResult, SpecWarning};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -225,6 +226,24 @@ impl<'a> Document<'a> {
         }
 
         Ok(self)
+    }
+
+    pub fn get_line_num(node: &Node) -> HowserResult<usize> {
+        let parent = node.capabilities
+            .traverse
+            .as_ref()
+            .ok_or(HowserError::CapabilityError)?
+            .parent()?;
+        let line_num = node.capabilities
+            .get
+            .as_ref()
+            .ok_or(HowserError::CapabilityError)?
+            .get_start_line()?;
+
+        match (parent, line_num) {
+            (Some(parent), 0) => Document::get_line_num(&parent),
+            _ => Ok(line_num as usize),
+        }
     }
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -227,6 +227,11 @@ impl<'a> Document<'a> {
         Ok(self)
     }
 
+    /// Infers the line number of the given node.
+    ///
+    /// Cmark reports that some inline and nested nodes are at line number zero which is usually
+    /// incorrect. This function searches up through the tree ancestry until it finds a parent node
+    /// that reports a sensible line number and returns that.
     pub fn get_line_num(node: &Node) -> HowserResult<usize> {
         let parent = node.capabilities
             .traverse

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -334,12 +334,16 @@ impl Reportable for TypeMismatchError {
 
     fn long_msg(&self) -> String {
         let mut message = format!("{}\n\n", Self::type_string());
-        message += &self.info.rx_location();
         message += &self.info.rx_type();
+        message += "\n";
+        message += &self.info.rx_location();
+        message += "\n";
         message += &self.info.rx_snippet();
         message += "\n\n";
-        message += &self.info.node_location();
         message += &self.info.node_type();
+        message += "\n";
+        message += &self.info.node_location();
+        message += "\n";
         message += &self.info.node_snippet();
         message
     }
@@ -453,7 +457,7 @@ fn file_info(filename: &str, line: usize) -> String {
 }
 
 fn node_type_string(node_type: &NodeType) -> String {
-    format!("{}{:?}{}\n", style::Bold, node_type, style::Reset)
+    format!("{}{:?}{}", style::Bold, node_type, style::Reset)
 }
 
 fn ok_text(text: &str) -> String {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,7 +6,7 @@ extern crate termion;
 use self::regex::Error as RegexError;
 use self::termion::color;
 use self::termion::style;
-use data::{ContentMatchPair, PromptToken};
+use data::ContentMatchPair;
 use document::{Document, Prescription};
 use doogie::constants::NodeType;
 use doogie::errors::DoogieError;
@@ -399,8 +399,8 @@ impl Reportable for TypeMismatchError {
             style::Reset
         );
 
-        let node_type = format!("{}{:?}{}", style::Bold, self.node_type, style::Reset);
-        let rx_type = format!("{}{:?}{}", style::Bold, self.rx_type, style::Reset);
+        let node_type = format!("{}{:?}{}\n", style::Bold, self.node_type, style::Reset);
+        let rx_type = format!("{}{:?}{}\n", style::Bold, self.rx_type, style::Reset);
 
         let mut message = format!(
             "{}Type Mismatch Error{}",
@@ -409,9 +409,11 @@ impl Reportable for TypeMismatchError {
         );
         message += "\n\n";
         message += &rx_info;
+        message += &rx_type;
         message += &cli::as_code_lines(&self.rx_snippet, self.rx_line).join("\n");
         message += "\n\n";
         message += &doc_info;
+        message += &node_type;
         message += &cli::as_code_lines(&self.doc_snippet, self.doc_line).join("\n");
         message
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -39,7 +39,7 @@ impl error::Error for HowserError {
             &HowserError::RuntimeError(ref message) => message,
             &HowserError::CapabilityError => "Capability Error",
             &HowserError::RegexError(ref error) => error.description(),
-            &HowserError::PrescriptionError(_) => "Prescription Error"
+            &HowserError::PrescriptionError(_) => "Prescription Error",
         }
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -185,7 +185,8 @@ impl Reportable for DocumentError {
             Self::type_string(),
             self.info.rx_location(),
             self.info.node_location(),
-            self.message())
+            self.message()
+        )
     }
 
     fn long_msg(&self) -> String {
@@ -218,9 +219,13 @@ struct ErrorInfo {
 }
 
 impl ErrorInfo {
-    fn new(rx_node: &Node, doc_node: &Node, rx: &Prescription, doc: &Document,) -> HowserResult<Self> {
-        let node_file = doc
-            .filename
+    fn new(
+        rx_node: &Node,
+        doc_node: &Node,
+        rx: &Prescription,
+        doc: &Document,
+    ) -> HowserResult<Self> {
+        let node_file = doc.filename
             .as_ref()
             .unwrap_or(&"Unknown".to_string())
             .to_string();
@@ -295,7 +300,7 @@ impl ErrorInfo {
 
 /// Error resulting from disparate Node types
 pub struct TypeMismatchError {
-    info: ErrorInfo
+    info: ErrorInfo,
 }
 
 impl TypeMismatchError {
@@ -305,7 +310,6 @@ impl TypeMismatchError {
         rx: &Prescription,
         doc: &Document,
     ) -> HowserResult<Self> {
-
         Ok(TypeMismatchError {
             info: ErrorInfo::new(rx_node, doc_node, rx, doc)?,
         })
@@ -375,7 +379,7 @@ impl TextualContentError {
             .map(|pair| {
                 let content = match pair {
                     ContentMatchPair(_, Some(ref content)) => content.to_owned(),
-                    _ => String::from("<No Match>")
+                    _ => String::from("<No Match>"),
                 };
                 match ContentMatchPair::is_match(pair) {
                     true => ok_text(&content),
@@ -398,7 +402,12 @@ impl TextualContentError {
 
 impl Reportable for TextualContentError {
     fn short_msg(&self) -> String {
-        format!("{}: at {}, {}", Self::type_string(), self.info.rx_location(), self.info.node_location())
+        format!(
+            "{}: at {}, {}",
+            Self::type_string(),
+            self.info.rx_location(),
+            self.info.node_location()
+        )
     }
 
     fn long_msg(&self) -> String {

--- a/src/helpers/cli/mod.rs
+++ b/src/helpers/cli/mod.rs
@@ -1,3 +1,8 @@
+extern crate termion;
+
+use self::termion::color;
+use self::termion::style;
+
 pub enum ShellText {
     Literal(String),
     WarningColor(Box<ShellText>),
@@ -36,17 +41,22 @@ impl ShellText {
     }
 }
 
-pub fn as_code_lines(code: &str, start_line: u32) -> Vec<String> {
+pub fn as_code_lines(code: &str, start_line: usize) -> Vec<String> {
     code.lines()
         .map(|line| {
-            ShellText::CodeColor(Box::new(ShellText::Literal(line.to_string()))).to_string()
+            format!(
+                "{}{}{}",
+                color::Fg(color::LightBlue),
+                line,
+                color::Fg(color::Reset)
+            )
         })
         .enumerate()
         .map(|(i, line)| {
-            let line_num = ShellText::Dim(Box::new(ShellText::Literal(
-                format!("{}    ", i as u32 + start_line)[..4].to_string(),
-            )));
-            format!("{} {}", line_num.to_string(), line)
+            let mut line_num = format!("{}{}    ", style::Faint, i + start_line);
+            line_num.truncate(6);
+            line_num += &style::Reset.to_string();
+            format!("{} {}", line_num, line)
         })
         .collect()
 }

--- a/src/helpers/cli/mod.rs
+++ b/src/helpers/cli/mod.rs
@@ -53,10 +53,8 @@ pub fn as_code_lines(code: &str, start_line: usize) -> Vec<String> {
         })
         .enumerate()
         .map(|(i, line)| {
-            let mut line_num = format!("{}{}    ", style::Faint, i + start_line);
-            line_num.truncate(6);
-            line_num += &style::Reset.to_string();
-            format!("{} {}", line_num, line)
+            let line_num = format!("{}{:<4}{}", style::Faint, i + start_line, style::Reset);
+            format!("{}{}", line_num, line)
         })
         .collect()
 }

--- a/src/reporters.rs
+++ b/src/reporters.rs
@@ -1,5 +1,8 @@
 //! Formatters for reporting validation results.
 
+extern crate termion;
+
+use self::termion::color;
 use errors::ValidationProblem;
 use helpers::cli::ShellText;
 
@@ -8,8 +11,6 @@ pub enum CLIOption {
     /// The message to be displayed for a valid document.
     SuccessMessage(String),
     /// the message to be displayed for an invalid document
-    FailureMessage(String),
-    /// The CLI is operating in verbose mode.
     VerboseMode(bool),
 }
 
@@ -18,15 +19,16 @@ pub fn make_cli_report(issues: &Option<ValidationProblem>, config: Vec<CLIOption
     let mut report: Vec<String> = Vec::new();
 
     let mut verbose_mode = false;
-    let mut success_message =
-        ShellText::OkColor(Box::new(ShellText::Literal("Rx Filled!".to_string()))).to_string();
-    let mut failure_message =
-        ShellText::ErrorColor(Box::new(ShellText::Literal("Rx Rejected!".to_string()))).to_string();
+    let mut success_message = format!(
+        "{}{}{}",
+        color::Fg(color::Green),
+        "Valid",
+        color::Fg(color::Reset)
+    );
 
     for option in config {
         match option {
             CLIOption::SuccessMessage(message) => success_message = message,
-            CLIOption::FailureMessage(message) => failure_message = message,
             CLIOption::VerboseMode(mode) => verbose_mode = mode,
         }
     }
@@ -38,10 +40,9 @@ pub fn make_cli_report(issues: &Option<ValidationProblem>, config: Vec<CLIOption
         });
     }
 
-    report.push(match issues {
-        None => success_message,
-        Some(_) => failure_message,
-    });
+    if issues.is_none() {
+        report.push(success_message);
+    }
 
     report.join("\n\n")
 }

--- a/src/reporters.rs
+++ b/src/reporters.rs
@@ -4,7 +4,6 @@ extern crate termion;
 
 use self::termion::color;
 use errors::ValidationProblem;
-use helpers::cli::ShellText;
 
 /// Options for configuring a CLI report.
 pub enum CLIOption {

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -31,12 +31,6 @@ struct OptionalMatchInput {
     bookmark: Option<Node>,
 }
 
-/// Return type for validating optional block level elements.
-struct OptionalMatchOutput {
-    rx: Option<Node>,
-    node: Option<Node>,
-}
-
 /// Type for managing the state of the validation process.
 struct MatchState {
     rx: Option<Node>,
@@ -476,7 +470,7 @@ impl<'a> Validator<'a> {
                             break;
                         }
                     }
-                    (MatchResult::Error(err), MatchType::Optional) => {
+                    (MatchResult::Error(_), MatchType::Optional) => {
                         break;
                     }
                     _ => {
@@ -638,7 +632,7 @@ impl<'a> Validator<'a> {
                         bookmark: bookmark,
                     }))
                 }
-                Some(err) => {
+                Some(_) => {
                     let next_rx = rx.capabilities
                         .traverse
                         .as_ref()
@@ -691,7 +685,7 @@ impl<'a> Validator<'a> {
                         bookmark: bookmark,
                     }))
                 }
-                Some(problem) => {
+                Some(_) => {
                     let next_rx = rx.capabilities
                         .traverse
                         .as_ref()

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1918,7 +1918,7 @@ mod tests {
         ) {
             let (template, document) = serialize_match_seq(matches);
 
-            let match_pairs = Validator::match_contents(&document, &template).unwrap();
+            let match_pairs = Validator::check_content_match(&document, &template).unwrap();
 
             assert!(! ContentMatchPair::contains_mismatch(&match_pairs));
         }
@@ -1930,7 +1930,7 @@ mod tests {
                 state + item
             });
 
-            let match_pairs = Validator::match_contents(&template, content).unwrap();
+            let match_pairs = Validator::check_content_match(&template, content).unwrap();
 
             assert!(ContentMatchPair::contains_mismatch(&match_pairs));
         }


### PR DESCRIPTION
This PR adds some significant improvements to error reporting usefulness. It reports correct line numbers and shows textual matching information. There are still some areas for improvement though, most notably with errors that arise from mismatching optional content and superfluous nodes.