### PR TITLE
Allow multiple targets per spec in pharmacy file

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1565,7 +1565,7 @@ mod tests {
 
         let report = validator.validate().unwrap();
 
-        assert!(report.is_none());
+        assert!(report.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Either a string or an array of strings may now be accepted as the value for a key-value pair in the Pharmacy.toml `[Specs]` table.